### PR TITLE
Cast all numeric values to String in AssertEquals method in case of

### DIFF
--- a/src/main/java/com/shaft/tools/support/JavaActions.java
+++ b/src/main/java/com/shaft/tools/support/JavaActions.java
@@ -77,7 +77,12 @@ public class JavaActions {
 		switch (comparisonType) {
 		case 1:
 		    // case sensitive literal equivalence
-		    Assert.assertTrue(actualValue.equals(expectedValue));
+			if (Number.class.equals(expectedValue.getClass()) || Number.class.equals(actualValue.getClass())) {
+			    Assert.assertTrue((String.valueOf(actualValue)).equals(String.valueOf(expectedValue)));
+			}
+			else {
+			    Assert.assertTrue(actualValue.equals(expectedValue));
+			}
 		    break;
 		case 2:
 		    // regex comparison
@@ -107,7 +112,12 @@ public class JavaActions {
 		switch (comparisonType) {
 		case 1:
 		    // case sensitive literal equivalence
-		    Assert.assertFalse(actualValue.equals(expectedValue));
+			if (Number.class.equals(expectedValue.getClass()) || Number.class.equals(actualValue.getClass())) {
+			    Assert.assertFalse((String.valueOf(actualValue)).equals(String.valueOf(expectedValue)));
+			}
+			else {
+			    Assert.assertFalse(actualValue.equals(expectedValue));
+			}
 		    break;
 		case 2:
 		    // regex comparison


### PR DESCRIPTION
Cast all numeric values to String in AssertEquals method in case of sensitive literal equivalence (in both true and false cases)