### PR TITLE
Added ElementAttributeType enums for the ValidateElementAttribute methods (#76)

### DIFF
--- a/src/main/java/com/shaft/validation/Assertions.java
+++ b/src/main/java/com/shaft/validation/Assertions.java
@@ -119,6 +119,23 @@ public class Assertions {
     /**
      * Asserts webElement attribute equals expectedValue.
      *
+     * @param driver                the current instance of Selenium webdriver
+     * @param elementLocator        the locator of the webElement under test (By xpath,
+     *                              id, selector, name ...etc)
+     * @param elementAttributeType  the desired attribute type of the webElement under test
+     * @param expectedValue         the expected value (test data) of this assertion
+     * @param customLogMessage      a custom message that will appended to this step in
+     *                              the execution report
+     */
+    public static void assertElementAttribute(WebDriver driver, By elementLocator, ElementAttributeType elementAttributeType,
+                                              String expectedValue, String... customLogMessage) {
+        ValidationHelper.validateElementAttribute(ValidationHelper.ValidationCategory.HARD_ASSERT, driver, elementLocator, elementAttributeType.getValue(), expectedValue,
+                ValidationComparisonType.EQUALS, ValidationType.POSITIVE, customLogMessage);
+    }
+
+    /**
+     * Asserts webElement attribute equals expectedValue.
+     *
      * @param driver           the current instance of Selenium webdriver
      * @param elementLocator   the locator of the webElement under test (By xpath,
      *                         id, selector, name ...etc)
@@ -136,7 +153,31 @@ public class Assertions {
     /**
      * Asserts webElement attribute equals expectedValue if AssertionType is
      * POSITIVE, or does not equal expectedValue if AssertionType is NEGATIVE.
-     * Supports Text, TagName, Size, Other Attributes
+     *
+     * @param driver                  the current instance of Selenium webdriver
+     * @param elementLocator          the locator of the webElement under test (By
+     *                                xpath, id, selector, name ...etc)
+     * @param elementAttributeType    the desired attribute type of the webElement under
+     *                                test
+     * @param expectedValue           the expected value (test data) of this
+     *                                assertion
+     * @param assertionComparisonType AssertionComparisonType.EQUALS, CONTAINS,
+     *                                MATCHES, CASE_INSENSITIVE
+     * @param assertionType           AssertionType.POSITIVE, NEGATIVE
+     * @param customLogMessage        a custom message that will appended to this
+     *                                step in the execution report
+     */
+    public static void assertElementAttribute(WebDriver driver, By elementLocator, ElementAttributeType elementAttributeType,
+                                              String expectedValue, AssertionComparisonType assertionComparisonType, AssertionType assertionType,
+                                              String... customLogMessage) {
+        ValidationHelper.validateElementAttribute(ValidationHelper.ValidationCategory.HARD_ASSERT, driver, elementLocator, elementAttributeType.getValue(), expectedValue,
+                ValidationComparisonType.valueOf(assertionComparisonType.toString()),
+                ValidationType.valueOf(assertionType.toString()), customLogMessage);
+    }
+
+    /**
+     * Asserts webElement attribute equals expectedValue if AssertionType is
+     * POSITIVE, or does not equal expectedValue if AssertionType is NEGATIVE.
      *
      * @param driver                  the current instance of Selenium webdriver
      * @param elementLocator          the locator of the webElement under test (By
@@ -576,5 +617,19 @@ public class Assertions {
         STRICT_EYES,
         CONTENT_EYES,
         LAYOUT_EYES
+    }
+
+    public enum ElementAttributeType {
+        TEXT("text"), TAG_NAME("tagname"), SIZE("size"), SELECTED_TEXT("selectedtext");
+
+        private final String value;
+
+        ElementAttributeType(String type) {
+            this.value = type;
+        }
+
+        protected String getValue() {
+            return value;
+        }
     }
 }

--- a/src/main/java/com/shaft/validation/Verifications.java
+++ b/src/main/java/com/shaft/validation/Verifications.java
@@ -125,6 +125,23 @@ public class Verifications {
     /**
      * verifies webElement attribute equals expectedValue.
      *
+     * @param driver                the current instance of Selenium webdriver
+     * @param elementLocator        the locator of the webElement under test (By xpath,
+     *                              id, selector, name ...etc)
+     * @param elementAttributeType  the desired attribute type of the webElement under test
+     * @param expectedValue         the expected value (test data) of this verification
+     * @param customLogMessage      a custom message that will appended to this step in
+     *                              the execution report
+     */
+    public static void verifyElementAttribute(WebDriver driver, By elementLocator, ElementAttributeType elementAttributeType,
+                                              String expectedValue, String... customLogMessage) {
+        ValidationHelper.validateElementAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, elementLocator, elementAttributeType.getValue(), expectedValue,
+                ValidationHelper.ValidationComparisonType.EQUALS, ValidationHelper.ValidationType.POSITIVE, customLogMessage);
+    }
+
+    /**
+     * verifies webElement attribute equals expectedValue.
+     *
      * @param driver           the current instance of Selenium webdriver
      * @param elementLocator   the locator of the webElement under test (By xpath,
      *                         id, selector, name ...etc)
@@ -137,6 +154,32 @@ public class Verifications {
                                               String expectedValue, String... customLogMessage) {
         ValidationHelper.validateElementAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, elementLocator, elementAttribute, expectedValue,
                 ValidationHelper.ValidationComparisonType.EQUALS, ValidationHelper.ValidationType.POSITIVE, customLogMessage);
+    }
+
+    /**
+     * verifies webElement attribute equals expectedValue if verificationType is
+     * POSITIVE, or does not equal expectedValue if verificationType is NEGATIVE.
+     * Supports Text, TagName, Size, Other Attributes
+     *
+     * @param driver                     the current instance of Selenium webdriver
+     * @param elementLocator             the locator of the webElement under test (By
+     *                                   xpath, id, selector, name ...etc)
+     * @param elementAttributeType       the desired attribute type of the webElement under
+     *                                   test
+     * @param expectedValue              the expected value (test data) of this
+     *                                   verification
+     * @param verificationComparisonType verificationComparisonType.EQUALS, CONTAINS,
+     *                                   MATCHES, CASE_INSENSITIVE
+     * @param verificationType           verificationType.POSITIVE, NEGATIVE
+     * @param customLogMessage           a custom message that will appended to this
+     *                                   step in the execution report
+     */
+    public static void verifyElementAttribute(WebDriver driver, By elementLocator, ElementAttributeType elementAttributeType,
+                                              String expectedValue, Verifications.VerificationComparisonType verificationComparisonType, Verifications.VerificationType verificationType,
+                                              String... customLogMessage) {
+        ValidationHelper.validateElementAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, elementLocator, elementAttributeType.getValue(), expectedValue,
+                ValidationHelper.ValidationComparisonType.valueOf(verificationComparisonType.toString()),
+                ValidationHelper.ValidationType.valueOf(verificationType.toString()), customLogMessage);
     }
 
     /**
@@ -582,5 +625,19 @@ public class Verifications {
         STRICT_EYES,
         CONTENT_EYES,
         LAYOUT_EYES
+    }
+
+    public enum ElementAttributeType {
+        TEXT("text"), TAG_NAME("tagname"), SIZE("size"), SELECTED_TEXT("selectedtext");
+
+        private final String value;
+
+        ElementAttributeType(String type) {
+            this.value = type;
+        }
+
+        protected String getValue() {
+            return value;
+        }
     }
 }

--- a/src/test/java/unitTests/tests_validations_assertions.java
+++ b/src/test/java/unitTests/tests_validations_assertions.java
@@ -214,6 +214,13 @@ public class tests_validations_assertions {
     }
 
     @Test(groups = {"WebBased"})
+    public void assertElementAttribute_type_true_literalComparison_expectedToPass() {
+        ElementActions.type(driver, By.name("q"), "Automation!@#$%^&*()_+{}[]\\';/.,");
+        Assertions.assertElementAttribute(driver, By.name("q"), Assertions.ElementAttributeType.TEXT, "Automation!@#$%^&*()_+{}[]\\';/.,",
+                AssertionComparisonType.EQUALS, AssertionType.POSITIVE);
+    }
+
+    @Test(groups = {"WebBased"})
     public void assertElementAttribute_true_literalComparison_expectedToPass() {
         ElementActions.type(driver, By.name("q"), "Automation!@#$%^&*()_+{}[]\\';/.,");
         Assertions.assertElementAttribute(driver, By.name("q"), "text", "Automation!@#$%^&*()_+{}[]\\';/.,",


### PR DESCRIPTION
**Changes**: 
* public enum ElementAttributeType in both Assertions and Verifications classes
*  Implement an overloaded methods to take these enums for the common attributes or a string for any other needed attribute.
* Added a unit testing case to test the ElementAttributeType method.