### PR TITLE
Add enums for the verify/assertBrowserAttribute method #299

### DIFF
--- a/src/main/java/com/shaft/validation/Assertions.java
+++ b/src/main/java/com/shaft/validation/Assertions.java
@@ -282,6 +282,45 @@ public class Assertions {
                 ValidationType.valueOf(assertionType.toString()), customLogMessage);
     }
 
+
+    /**
+     * Asserts browser attribute equals expectedValue. Supports
+     *
+     * @param driver                the current instance of Selenium webdriver
+     * @param browserAttributeType  the desired attribute type of the browser window
+     *                              under test
+     * @param expectedValue         the expected value (test data) of this
+     *                              assertion
+     * @param customLogMessage      a custom message that will appended to this
+     *                              step in the execution report
+     */
+    public static void assertBrowserAttribute(WebDriver driver, BrowserAttributeType browserAttributeType, String expectedValue,
+                                              String... customLogMessage) {
+        ValidationHelper.validateBrowserAttribute(ValidationHelper.ValidationCategory.HARD_ASSERT, driver, browserAttributeType.getValue(), expectedValue, ValidationComparisonType.EQUALS,
+                ValidationType.POSITIVE, customLogMessage);
+    }
+
+    /**
+     * Asserts browser attribute equals expectedValue if AssertionType is POSITIVE,
+     * or does not equal expectedValue if AssertionType is NEGATIVE. Supports
+     *
+     * @param driver                  the current instance of Selenium webdriver
+     * @param browserAttributeType    the desired attribute type of the browser window
+     *                                under test
+     * @param expectedValue           the expected value (test data) of this
+     *                                assertion
+     * @param assertionComparisonType AssertionComparisonType.EQUALS, CONTAINS,
+     *                                MATCHES, CASE_INSENSITIVE
+     * @param assertionType           AssertionType.POSITIVE, NEGATIVE
+     * @param customLogMessage        a custom message that will appended to this
+     *                                step in the execution report
+     */
+    public static void assertBrowserAttribute(WebDriver driver, BrowserAttributeType browserAttributeType, String expectedValue,
+                                              AssertionComparisonType assertionComparisonType, AssertionType assertionType, String... customLogMessage) {
+        ValidationHelper.validateBrowserAttribute(ValidationHelper.ValidationCategory.HARD_ASSERT, driver, browserAttributeType.getValue(), expectedValue, ValidationComparisonType.valueOf(assertionComparisonType.toString()),
+                ValidationType.valueOf(assertionType.toString()), customLogMessage);
+    }
+
     /**
      * Asserts that the expectedValue is related to the actualValue using the
      * desired comparativeRelationType.
@@ -625,6 +664,20 @@ public class Assertions {
         private final String value;
 
         ElementAttributeType(String type) {
+            this.value = type;
+        }
+
+        protected String getValue() {
+            return value;
+        }
+    }
+
+    public enum BrowserAttributeType {
+        CURRENT_URL("currenturl"), PAGE_SOURCE("pagesource"), TITLE("title"), WINDOW_HANDLE("windowhandle"), WINDOW_POSITION("windowposition"), WINDOW_SIZE("windowsize");
+
+        private final String value;
+
+        BrowserAttributeType(String type) {
             this.value = type;
         }
 

--- a/src/main/java/com/shaft/validation/Verifications.java
+++ b/src/main/java/com/shaft/validation/Verifications.java
@@ -159,7 +159,6 @@ public class Verifications {
     /**
      * verifies webElement attribute equals expectedValue if verificationType is
      * POSITIVE, or does not equal expectedValue if verificationType is NEGATIVE.
-     * Supports Text, TagName, Size, Other Attributes
      *
      * @param driver                     the current instance of Selenium webdriver
      * @param elementLocator             the locator of the webElement under test (By
@@ -185,7 +184,6 @@ public class Verifications {
     /**
      * verifies webElement attribute equals expectedValue if verificationType is
      * POSITIVE, or does not equal expectedValue if verificationType is NEGATIVE.
-     * Supports Text, TagName, Size, Other Attributes
      *
      * @param driver                     the current instance of Selenium webdriver
      * @param elementLocator             the locator of the webElement under test (By
@@ -287,6 +285,44 @@ public class Verifications {
     public static void verifyBrowserAttribute(WebDriver driver, String browserAttribute, String expectedValue,
                                               Verifications.VerificationComparisonType verificationComparisonType, Verifications.VerificationType verificationType, String... customLogMessage) {
         ValidationHelper.validateBrowserAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, browserAttribute, expectedValue, ValidationHelper.ValidationComparisonType.valueOf(verificationComparisonType.toString()),
+                ValidationHelper.ValidationType.valueOf(verificationType.toString()), customLogMessage);
+    }
+
+    /**
+     * verifies browser attribute equals expectedValue. Supports
+     *
+     * @param driver                the current instance of Selenium webdriver
+     * @param browserAttributeType  the desired attribute type of the browser window
+     *                              under test
+     * @param expectedValue         the expected value (test data) of this
+     *                              verification
+     * @param customLogMessage      a custom message that will appended to this
+     *                              step in the execution report
+     */
+    public static void verifyBrowserAttribute(WebDriver driver, BrowserAttributeType browserAttributeType, String expectedValue,
+                                              String... customLogMessage) {
+        ValidationHelper.validateBrowserAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, browserAttributeType.getValue(), expectedValue, ValidationHelper.ValidationComparisonType.EQUALS,
+                ValidationHelper.ValidationType.POSITIVE, customLogMessage);
+    }
+
+    /**
+     * verifies browser attribute equals expectedValue if verificationType is POSITIVE,
+     * or does not equal expectedValue if verificationType is NEGATIVE. Supports
+     *
+     * @param driver                     the current instance of Selenium webdriver
+     * @param browserAttributeType       the desired attribute type of the browser window
+     *                                   under test
+     * @param expectedValue              the expected value (test data) of this
+     *                                   verification
+     * @param verificationComparisonType verificationComparisonType.EQUALS, CONTAINS,
+     *                                   MATCHES, CASE_INSENSITIVE
+     * @param verificationType           verificationType.POSITIVE, NEGATIVE
+     * @param customLogMessage           a custom message that will appended to this
+     *                                   step in the execution report
+     */
+    public static void verifyBrowserAttribute(WebDriver driver, BrowserAttributeType browserAttributeType, String expectedValue,
+                                              Verifications.VerificationComparisonType verificationComparisonType, Verifications.VerificationType verificationType, String... customLogMessage) {
+        ValidationHelper.validateBrowserAttribute(ValidationHelper.ValidationCategory.SOFT_ASSERT, driver, browserAttributeType.getValue(), expectedValue, ValidationHelper.ValidationComparisonType.valueOf(verificationComparisonType.toString()),
                 ValidationHelper.ValidationType.valueOf(verificationType.toString()), customLogMessage);
     }
 
@@ -633,6 +669,20 @@ public class Verifications {
         private final String value;
 
         ElementAttributeType(String type) {
+            this.value = type;
+        }
+
+        protected String getValue() {
+            return value;
+        }
+    }
+
+    public enum BrowserAttributeType {
+        CURRENT_URL("currenturl"), PAGE_SOURCE("pagesource"), TITLE("title"), WINDOW_HANDLE("windowhandle"), WINDOW_POSITION("windowposition"), WINDOW_SIZE("windowsize");
+
+        private final String value;
+
+        BrowserAttributeType(String type) {
             this.value = type;
         }
 


### PR DESCRIPTION
**Changes**
* Added public enum BrowserAttributeType in both Assertions and Verifications classes
* Implemented an overloaded methods to make use of these enums attribute and left the old methods unchanged.