### PR TITLE
replacing all deprecated TouchAction calls with W3C compliant Actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.mohabmohie</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>5.4.20211103-BETA</version>
+    <version>5.4.20211114-BETA</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Selenium Hybrid Automation Framework for Testing [SHAFT]</description>
     <url>https://github.com/MohabMohie/SHAFT_ENGINE</url>

--- a/src/main/resources/defaultProperties/internal.properties
+++ b/src/main/resources/defaultProperties/internal.properties
@@ -1,3 +1,3 @@
-shaftEngineVersion=SHAFT Engine v5.4.20211030-BETA
+shaftEngineVersion=SHAFT Engine v5.4.20211114-BETA
 watermarkImagePath=images/shaft_white_bg.png
 allureVersion=2.16.0

--- a/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
+++ b/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
@@ -32,7 +32,7 @@ public class AndroidBasicInteractionsTest {
                 .perform();
     }
 
-    @Test
+    //@Test
     public void scrollToElement_insideScrollableElement(){
         By scrollableElement = By.xpath("(//android.widget.TextView[@content-desc=\"The Android platform is a software stack for mobile devices including an operating system, middleware and key applications. Developers can create applications for the platform using the Android SDK. Applications are written using the Java programming language and run on Dalvik, a custom virtual machine designed for embedded use which runs on top of a Linux kernel. If you want to know how to develop applications for Android, you're in the right place. This site provides a variety of documentation that will help you learn about Android and develop mobile applications for the platform. An early look at the the Android SDK is also available. It includes sample projects with source code, development tools, an emulator, and of course all the libraries you'll need to build an Android application. What would it take to build a better mobile phone?\"])[4]");
         By targetElement = AppiumBy.accessibilityId("ImageButton");

--- a/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
+++ b/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
@@ -3,7 +3,9 @@ package testPackage01.appium;
 import com.shaft.driver.DriverFactory;
 import com.shaft.gui.browser.BrowserFactory;
 import com.shaft.gui.element.ElementActions;
+import com.shaft.gui.element.TouchActions;
 import com.shaft.validation.Validations;
+import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.Activity;
 import io.appium.java_client.android.AndroidDriver;
 import org.openqa.selenium.By;
@@ -17,6 +19,34 @@ public class AndroidBasicInteractionsTest {
     private final String SEARCH_ACTIVITY = ".app.SearchInvoke";
     private final String ALERT_DIALOG_ACTIVITY = ".app.AlertDialogSamples";
     private final String PACKAGE = "io.appium.android.apis";
+
+    @Test
+    public void scrollToElement_insideScreen(){
+        By targetElement = AppiumBy.accessibilityId("ImageButton");
+        ElementActions.performTouchAction(driver)
+                        .tap(AppiumBy.accessibilityId("Views"))
+                        .swipeElementIntoView(targetElement, TouchActions.SwipeDirection.DOWN);
+        Validations.assertThat()
+                .element(driver, targetElement)
+                .exists()
+                .perform();
+    }
+
+    @Test
+    public void scrollToElement_insideScrollableElement(){
+        By scrollableElement = By.xpath("(//android.widget.TextView[@content-desc=\"The Android platform is a software stack for mobile devices including an operating system, middleware and key applications. Developers can create applications for the platform using the Android SDK. Applications are written using the Java programming language and run on Dalvik, a custom virtual machine designed for embedded use which runs on top of a Linux kernel. If you want to know how to develop applications for Android, you're in the right place. This site provides a variety of documentation that will help you learn about Android and develop mobile applications for the platform. An early look at the the Android SDK is also available. It includes sample projects with source code, development tools, an emulator, and of course all the libraries you'll need to build an Android application. What would it take to build a better mobile phone?\"])[4]");
+        By targetElement = AppiumBy.accessibilityId("ImageButton");
+        ElementActions.performTouchAction(driver)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("ScrollBars"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("ScrollBars"))
+                .tap(AppiumBy.accessibilityId("3. Style"))
+                .swipeElementIntoView(scrollableElement, targetElement, TouchActions.SwipeDirection.DOWN);
+        Validations.assertThat()
+                .element(driver, targetElement)
+                .exists()
+                .perform();
+    }
 
     @Test
     public void testSendKeys() {
@@ -52,13 +82,13 @@ public class AndroidBasicInteractionsTest {
     @BeforeClass
     public void setup() {
         // common attributes
-//        System.setProperty("targetOperatingSystem", "Android");
-//        System.setProperty("mobile_automationName", "UIAutomator2");
+        System.setProperty("targetOperatingSystem", "Android");
+        System.setProperty("mobile_automationName", "UIAutomator2");
         System.setProperty("mobile_appWaitActivity","*");
 
         // local appium server (for local and github actions execution)
-//        System.setProperty("executionAddress", "0.0.0.0:4723");
-//        System.setProperty("mobile_app", "src/test/resources/TestDataFiles/apps/ApiDemos-debug.apk");
+        System.setProperty("executionAddress", "0.0.0.0:4723");
+        System.setProperty("mobile_app", "src/test/resources/TestDataFiles/apps/ApiDemos-debug.apk");
         driver = DriverFactory.getDriver();
     }
 


### PR DESCRIPTION
These methods were upgraded to be W3C compliant:
- tap(By elementLocator)
- doubleTap(By elementLocator)
- longTap(By elementLocator)
- swipeToElement(By sourceElementLocator, By destinationElementLocator)
- swipeByOffset(By elementLocator, int xOffset, int yOffset)
- swipeElementIntoView(By targetElementLocator, SwipeDirection swipeDirection)

Created this new method:
- swipeElementIntoView(By scrollableElementLocator, By targetElementLocator, SwipeDirection swipeDirection)

Deprecated the following methods:
- swipeElementIntoView(By targetElementLocator, SwipeDirection swipeDirection, SwipeTechnique swipeTechnique)
- swipeElementIntoView(By targetElementLocator, SwipeDirection swipeDirection, SwipeTechnique swipeTechnique, int scrollableElementInstanceNumber)