### PR TITLE
optimizing w3c compliant scroll

### DIFF
--- a/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -600,9 +600,8 @@ public class TouchActions {
     private boolean attemptToSwipeElementIntoViewInNativeApp(By scrollableElementLocator, By targetElementLocator, SwipeDirection swipeDirection) {
         boolean isElementFound = false;
         boolean canStillScroll = true;
-
+        var isDiscrete = ReportManagerHelper.getDiscreteLogging();
         do {
-            var isDiscrete = ReportManagerHelper.getDiscreteLogging();
             ReportManagerHelper.setDiscreteLogging(true);
             // appium native device
             if (!driver.findElements(targetElementLocator).isEmpty()
@@ -618,6 +617,17 @@ public class TouchActions {
                 canStillScroll = attemptW3cCompliantActionsScroll(swipeDirection, scrollableElementLocator, targetElementLocator);
             }
         } while (Boolean.FALSE.equals(isElementFound) && Boolean.TRUE.equals(canStillScroll));
+
+        //final check after reaching the end of the scrollable area
+        ReportManagerHelper.setDiscreteLogging(true);
+        if (Boolean.FALSE.equals(isElementFound)
+            && !driver.findElements(targetElementLocator).isEmpty()
+            && WebDriverElementActions.isElementDisplayed(driver, targetElementLocator)){
+                ReportManagerHelper.setDiscreteLogging(isDiscrete);
+                // element is already on screen
+                isElementFound = true;
+                ReportManager.logDiscrete("Element found on screen.");
+        }
         return isElementFound;
     }
     
@@ -651,10 +661,14 @@ public class TouchActions {
                     "height", elementRectangle.getHeight()
             ));
         }else{
+            switch (swipeDirection){
+                case UP -> scrollParameters.putAll(ImmutableMap.of("left", 0, "top", screenSize.getHeight() - 100));
+                case DOWN -> scrollParameters.putAll(ImmutableMap.of("left", 0, "top", 100));
+                case LEFT -> scrollParameters.putAll(ImmutableMap.of("left", screenSize.getWidth() - 100, "top", 0));
+                case RIGHT -> scrollParameters.putAll(ImmutableMap.of("left", 100, "top", 0));
+            }
             //scrolling inside the screen
             scrollParameters.putAll(ImmutableMap.of(
-                    "left", 0,
-                    "top", 100,
                     "width", screenSize.getWidth(),
                     "height", screenSize.getHeight()
             ));

--- a/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
+++ b/src/test/java/testPackage01/appium/AndroidBasicInteractionsTest.java
@@ -23,11 +23,48 @@ public class AndroidBasicInteractionsTest {
         By targetElement = AppiumBy.accessibilityId("ImageButton");
         ElementActions.performTouchAction(driver)
                         .tap(AppiumBy.accessibilityId("Views"))
-                        .swipeElementIntoView(targetElement, TouchActions.SwipeDirection.DOWN);
+                .swipeElementIntoView(targetElement, TouchActions.SwipeDirection.DOWN);
         Validations.assertThat()
                 .element(driver, targetElement)
                 .exists()
                 .perform();
+    }
+
+    @Test
+    public void scrollInExpandableLists_verticalScrolling(){
+        ElementActions.performTouchAction(driver)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .tap(AppiumBy.accessibilityId("Expandable Lists"))
+                .tap(AppiumBy.accessibilityId("3. Simple Adapter"))
+                .swipeElementIntoView(By.xpath("//android.widget.TextView[@text='Group 18']"), TouchActions.SwipeDirection.DOWN)
+                .tap(By.xpath("//android.widget.TextView[@text='Group 18']"))
+                .swipeElementIntoView(By.xpath("//android.widget.TextView[@text='Child 13']"), TouchActions.SwipeDirection.DOWN)
+                .swipeElementIntoView(By.xpath("//android.widget.TextView[@text='Group 1']"), TouchActions.SwipeDirection.UP);
+    }
+
+    @Test
+    public void scrollInExpandableLists_verticalScrolling_insideElement(){
+        ElementActions.performTouchAction(driver)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("Splitting Touches across Views"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Splitting Touches across Views"))
+                .swipeElementIntoView(By.id("io.appium.android.apis:id/list1"), By.xpath("//android.widget.ListView[1]/android.widget.TextView[@text='Blue']"), TouchActions.SwipeDirection.DOWN)
+                .tap(By.xpath("//android.widget.ListView[1]/android.widget.TextView[@text='Blue']"))
+                .swipeElementIntoView(By.id("io.appium.android.apis:id/list1"), By.xpath("//android.widget.ListView[1]/android.widget.TextView[@text='Abbaye de Belloc']"), TouchActions.SwipeDirection.UP)
+                .tap(By.xpath("//android.widget.ListView[1]/android.widget.TextView[@text='Abbaye de Belloc']"));
+    }
+
+    @Test
+    public void scrollInExpandableLists_horizontalScrolling_insideElement(){
+        ElementActions.performTouchAction(driver)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("Tabs"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Tabs"))
+                .tap(AppiumBy.accessibilityId("5. Scrollable"))
+                .swipeElementIntoView(By.xpath("//android.widget.HorizontalScrollView"), By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 12']"), TouchActions.SwipeDirection.RIGHT)
+                .tap(By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 12']"))
+                .swipeElementIntoView(By.xpath("//android.widget.HorizontalScrollView"), By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 1']"), TouchActions.SwipeDirection.LEFT)
+                .tap(By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 1']"));
     }
 
 //    @Test
@@ -40,10 +77,6 @@ public class AndroidBasicInteractionsTest {
                 .tap(AppiumBy.accessibilityId("ScrollBars"))
                 .tap(AppiumBy.accessibilityId("3. Style"))
                 .swipeElementIntoView(scrollableElement, targetElement, TouchActions.SwipeDirection.DOWN);
-        Validations.assertThat()
-                .element(driver, targetElement)
-                .exists()
-                .perform();
     }
 
     @Test


### PR DESCRIPTION
- fixing issue whereby SHAFT fails to find the element if at the end of the current screen or scrollable element view
- handling different cases per swipe direction on main application screen (up, down, left, right)
- testing screen scroll vertically up and down
- testing nested element scroll vertically up and down
- testing nested element scroll horizontally up and down