### PR TITLE
created the new custom cucumber listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.mohabmohie</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>6.1.20220224</version>
+    <version>6.1.20220313</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Selenium Hybrid Automation Framework for Testing [SHAFT]</description>
     <url>https://github.com/MohabMohie/SHAFT_ENGINE</url>
@@ -292,6 +292,11 @@
                     <artifactId>testng</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-cucumber7-jvm</artifactId>
+            <version>${allure-testng.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/src/main/java/com/shaft/cucumber/BrowserSteps.java
+++ b/src/main/java/com/shaft/cucumber/BrowserSteps.java
@@ -1,5 +1,6 @@
 package com.shaft.cucumber;
 
+import com.shaft.driver.DriverFactory;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.browser.BrowserFactory;
 import io.cucumber.java.en.Given;
@@ -21,7 +22,7 @@ public class BrowserSteps {
     @Given("I Open the target browser")
 //    @بفرض("انى قمت بفتح المتصفح المطلوب")
     public void getBrowser() {
-        driver.set(BrowserFactory.getBrowser());
+        driver.set(DriverFactory.getDriver());
     }
 
     /**

--- a/src/main/java/com/shaft/gui/image/ImageProcessingActions.java
+++ b/src/main/java/com/shaft/gui/image/ImageProcessingActions.java
@@ -642,9 +642,10 @@ public class ImageProcessingActions {
             try {
                 OpenCV.loadLocally();
                 ReportManager.logDiscrete("Loaded Local OpenCV");
-            } catch (UnsatisfiedLinkError e2) {
-                ReportManagerHelper.log(e);
-                ReportManager.logDiscrete("Failed to load OpenCV");
+            } catch (Throwable throwable) {
+                ReportManagerHelper.log(throwable);
+                ReportManager.logDiscrete("Failed to load OpenCV, switching to JavaScript.");
+                System.setProperty("screenshotParams_highlightMethod","JavaScript");
             }
         }
     }

--- a/src/main/java/com/shaft/tools/io/LogsHelper.java
+++ b/src/main/java/com/shaft/tools/io/LogsHelper.java
@@ -1,8 +1,8 @@
 package com.shaft.tools.io;
 
 import com.shaft.cli.FileActions;
+import com.shaft.driver.DriverFactory;
 import com.shaft.driver.DriverFactoryHelper;
-import com.shaft.gui.browser.BrowserFactory;
 import org.testng.ITestContext;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
@@ -34,7 +34,7 @@ public class LogsHelper {
 
     @AfterSuite
     public void teardownActivities() {
-        attachBrowserLogs();
+        closeAllDriversAndattachBrowserLogs();
         attachFullLogs();
         attachCucumberReport();
         attachExtentReport();
@@ -43,19 +43,19 @@ public class LogsHelper {
         ReportManagerHelper.openAllureReportAfterExecution();
     }
 
-    public void attachFullLogs() {
+    public static void attachFullLogs() {
         String executionEndTimestamp = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
         ReportManagerHelper.attachIssuesLog(executionEndTimestamp);
         ReportManagerHelper.attachFullLog(executionEndTimestamp);
     }
 
-    public void attachBrowserLogs() {
+    public static void closeAllDriversAndattachBrowserLogs() {
         if (Boolean.FALSE.equals(DriverFactoryHelper.isDriversListEmpty())) {
-            BrowserFactory.closeAllBrowsers();
+            DriverFactory.closeAllDrivers();
         }
     }
 
-    private void attachImportantLinks() {
+    public static void attachImportantLinks() {
         ReportManager.logDiscrete("Initializing Important Links...");
         System.setProperty("disableLogging", "true");
         String importantLinks = "#SHAFT: Important Links" +
@@ -82,7 +82,7 @@ public class LogsHelper {
         System.setProperty("disableLogging", "false");
     }
 
-    private void attachPropertyFiles() {
+    public static void attachPropertyFiles() {
         ReportManager.logDiscrete("Initializing Custom Properties...");
         System.setProperty("disableLogging", "true");
         if (FileActions.doesFileExist(System.getProperty("propertiesFolderPath"))) {
@@ -92,13 +92,13 @@ public class LogsHelper {
         System.setProperty("disableLogging", "false");
     }
 
-    private void attachCucumberReport() {
+    public static void attachCucumberReport() {
         if (FileActions.doesFileExist("allure-results/cucumberReport.html")) {
             ReportManagerHelper.attach("HTML", "Cucumber Execution Report", FileActions.readFromFile("allure-results/cucumberReport.html"));
         }
     }
 
-    private void attachExtentReport() {
+    public static void attachExtentReport() {
         ReportManagerHelper.extentReportsFlush();
         if (Boolean.parseBoolean(System.getProperty("generateExtentReports").trim()) && FileActions.doesFileExist(ReportManagerHelper.getExtentReportFileName())) {
             ReportManagerHelper.attach("HTML", "Extent Emailable Execution Report", FileActions.readFromFile(ReportManagerHelper.getExtentReportFileName()));

--- a/src/main/java/com/shaft/tools/listeners/AlterSuiteListener.java
+++ b/src/main/java/com/shaft/tools/listeners/AlterSuiteListener.java
@@ -12,12 +12,13 @@ import org.testng.annotations.ITestAnnotation;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlSuite.ParallelMode;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.List;
 
 public class AlterSuiteListener implements IAlterSuiteListener, IRetryAnalyzer, IAnnotationTransformer,
-        IInvokedMethodListener, ITestListener, IExecutionListener {
+        IInvokedMethodListener, IExecutionListener {
 
     private int retryCount = 0;
     private static int retryMaximumNumberOfAttempts = 0;
@@ -60,7 +61,8 @@ public class AlterSuiteListener implements IAlterSuiteListener, IRetryAnalyzer, 
     }
 
     private void renameDefaultSuiteAndTest(List<XmlSuite> suites) {
-        var prefix = "SHAFT: ";
+//        var prefix = "SHAFT: ";
+        var prefix = "";
         // rename default suite and test
         suites.forEach(suite -> {
             if (suite.getName().trim().equalsIgnoreCase("default suite")
@@ -89,8 +91,7 @@ public class AlterSuiteListener implements IAlterSuiteListener, IRetryAnalyzer, 
     private void addListeners(List<XmlSuite> suites) {
         suites.forEach(suite -> {
             suite.addListener("com.shaft.tools.listeners.InvokedMethodListener");
-            suite.addListener("com.shaft.tools.listeners.XRayListener");
-//            suite.addListener("com.shaft.tools.listeners.SuiteListener");
+//            suite.addListener("com.shaft.tools.listeners.CucumberFeatureListener");
         });
 
     }
@@ -150,13 +151,16 @@ public class AlterSuiteListener implements IAlterSuiteListener, IRetryAnalyzer, 
 
     @Override
     public void onExecutionStart() {
-        ReportManager.logDiscrete("TestNG is going to start");
-
+//        ReportManager.logDiscrete("TestNG is going to start");
     }
 
     @Override
     public void onExecutionFinish() {
-        ReportManager.logDiscrete("TestNG is finished");
+//        ReportManager.logDiscrete("TestNG is finished");
+        reportExecutionStatusToJira();
+    }
+
+    public static void reportExecutionStatusToJira(){
         if(System.getProperty("jiraInteraction").equalsIgnoreCase("true"))
         {
             try {

--- a/src/main/java/com/shaft/tools/listeners/CucumberFeatureListener.java
+++ b/src/main/java/com/shaft/tools/listeners/CucumberFeatureListener.java
@@ -1,63 +1,207 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.shaft.tools.listeners;
 
 import com.shaft.cli.FileActions;
+import com.shaft.driver.DriverFactoryHelper;
 import com.shaft.gui.element.ElementActions;
-import com.shaft.tools.io.PropertyFileManager;
-import com.shaft.tools.io.ReportManager;
-import com.shaft.tools.io.ReportManagerHelper;
+import com.shaft.gui.image.ImageProcessingActions;
+import com.shaft.gui.image.ScreenshotManager;
+import com.shaft.gui.video.RecordManager;
+import com.shaft.tools.io.*;
 import io.cucumber.core.feature.FeatureParser;
-import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.resource.Resource;
+import io.cucumber.messages.types.Examples;
+import io.cucumber.messages.types.Feature;
+import io.cucumber.messages.types.Scenario;
+import io.cucumber.messages.types.TableRow;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.*;
+import io.qameta.allure.Allure;
+import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.cucumber7jvm.testsourcemodel.TestSourcesModelProxy;
+import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Parameter;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StatusDetails;
+import io.qameta.allure.model.StepResult;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.model.TestResultContainer;
+import org.testng.Reporter;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.getStatus;
+import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
+import static io.qameta.allure.util.ResultsUtils.md5;
+
+/**
+ * Allure plugin for Cucumber JVM 7.0.
+ */
+@SuppressWarnings({
+        "ClassDataAbstractionCoupling",
+        "ClassFanOutComplexity",
+        "PMD.ExcessiveImports",
+        "PMD.GodClass",
+})
 public class CucumberFeatureListener implements ConcurrentEventListener {
 
+    private final AllureLifecycle lifecycle;
+
+    private final ConcurrentHashMap<String, String> scenarioUuids = new ConcurrentHashMap<>();
+    private final TestSourcesModelProxy testSources = new TestSourcesModelProxy();
+
+    private final ThreadLocal<Feature> currentFeature = new InheritableThreadLocal<>();
+    private final ThreadLocal<URI> currentFeatureFile = new InheritableThreadLocal<>();
+    private final ThreadLocal<TestCase> currentTestCase = new InheritableThreadLocal<>();
+    private final ThreadLocal<String> currentContainer = new InheritableThreadLocal<>();
+    private final ThreadLocal<Boolean> forbidTestCaseStatusChange = new InheritableThreadLocal<>();
+
+    private final EventHandler<TestSourceRead> featureStartedHandler = this::handleFeatureStartedHandler;
+    private final EventHandler<TestCaseStarted> caseStartedHandler = this::handleTestCaseStarted;
+    private final EventHandler<TestCaseFinished> caseFinishedHandler = this::handleTestCaseFinished;
+    private final EventHandler<TestStepStarted> stepStartedHandler = this::handleTestStepStarted;
+    private final EventHandler<TestStepFinished> stepFinishedHandler = this::handleTestStepFinished;
+    private final EventHandler<WriteEvent> writeEventHandler = this::handleWriteEvent;
+    private final EventHandler<EmbedEvent> embedEventHandler = this::handleEmbedEvent;
+
+    private static final String TXT_EXTENSION = ".txt";
+    private static final String TEXT_PLAIN = "text/plain";
+
+    private static String lastStartedScenarioName;
+    public static String getLastStartedScenarioName(){
+        return lastStartedScenarioName;
+    }
+
+    private static Boolean isLastFinishedStepOK;
+    public static Boolean getIsLastFinishedStepOK(){
+        return isLastFinishedStepOK;
+    }
+
+    @SuppressWarnings("unused")
+    public CucumberFeatureListener() {
+        this(Allure.getLifecycle());
+    }
+
+    public CucumberFeatureListener(final AllureLifecycle lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    /*
+    Event Handlers
+     */
     @Override
-    public void setEventPublisher(EventPublisher publisher) {
-        //https://github.com/cucumber/cucumber-jvm/issues/1901
-        //https://github.com/cucumber/cucumber-jvm/issues/1901#issuecomment-600494342
-        publisher.registerHandlerFor(TestRunStarted.class, this::handleTestRunStarted);
-        publisher.registerHandlerFor(TestRunFinished.class, this::handleTestRunFinished);
-        publisher.registerHandlerFor(TestCaseStarted.class, this::handleTestCaseStarted);
-        publisher.registerHandlerFor(TestStepStarted.class, this::handleTestStepStarted);
+    public void setEventPublisher(final EventPublisher publisher) {
+        publisher.registerHandlerFor(TestSourceRead.class, featureStartedHandler);
+
+        publisher.registerHandlerFor(TestCaseStarted.class, caseStartedHandler);
+        publisher.registerHandlerFor(TestCaseFinished.class, caseFinishedHandler);
+
+        publisher.registerHandlerFor(TestStepStarted.class, stepStartedHandler);
+        publisher.registerHandlerFor(TestStepFinished.class, stepFinishedHandler);
+
+        publisher.registerHandlerFor(WriteEvent.class, writeEventHandler);
+        publisher.registerHandlerFor(EmbedEvent.class, embedEventHandler);
+
+        // custom handlers
         publisher.registerHandlerFor(TestSourceParsed.class, this::handleTestSourceParsed);
     }
 
-    private void handleTestRunStarted(TestRunStarted event) {
-        PropertyFileManager.readPropertyFiles();
+    private void handleFeatureStartedHandler(final TestSourceRead event) {
+        testSources.addTestSourceReadEvent(event.getUri(), event);
     }
 
-    private void handleTestRunFinished(TestRunFinished event) {
-        ElementActions.switchToDefaultContent();
-        if(Boolean.parseBoolean(System.getProperty("generateExtentReports").trim())){
-            ReportManagerHelper.extentReportsReset();
+    private void handleTestCaseStarted(final TestCaseStarted event) {
+        // custom code
+        shaftSetup();
+        // end of custom code
+        currentFeatureFile.set(event.getTestCase().getUri());
+        currentFeature.set(testSources.getFeature(currentFeatureFile.get()));
+        currentTestCase.set(event.getTestCase());
+        currentContainer.set(UUID.randomUUID().toString());
+        forbidTestCaseStatusChange.set(false);
+
+        final Deque<String> tags = new LinkedList<>(currentTestCase.get().getTags());
+
+        final Feature feature = currentFeature.get();
+
+        final String name = currentTestCase.get().getName();
+        final String featureName = feature.getName();
+
+        final TestResult result = new TestResult()
+                .setUuid(getTestCaseUuid(currentTestCase.get()))
+                .setHistoryId(getHistoryId(currentTestCase.get()))
+                .setFullName(featureName + ": " + name)
+                .setName(name);
+
+        final Scenario scenarioDefinition =
+                testSources.getScenarioDefinition(
+                        currentFeatureFile.get(),
+                        currentTestCase.get().getLocation().getLine()
+                );
+
+        if (scenarioDefinition.getExamples() != null) {
+            result.setParameters(
+                    getExamplesAsParameters(scenarioDefinition, currentTestCase.get())
+            );
         }
-    }
 
-    private void handleTestSourceParsed(TestSourceParsed event) {
-        event.getNodes().forEach(node -> {
-            Optional<Feature> feature = getFeature(event.getUri());
-            if (feature.isPresent()) {
-                if (ReportManagerHelper.getTotalNumberOfTests() == 0) {
-                    ReportManagerHelper.setTotalNumberOfTests(feature.get().getPickles().size());
-                } else {
-                    ReportManagerHelper.setTotalNumberOfTests(ReportManagerHelper.getTotalNumberOfTests() + feature.get().getPickles().size());
-                }
-            }
-        });
-        PropertyFileManager.readPropertyFiles();
-    }
+        final String description = Stream.of(feature.getDescription(), scenarioDefinition.getDescription())
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining("\n"));
 
-    private void handleTestCaseStarted(TestCaseStarted event) {
-    	var testCase = event.getTestCase();
-    	var scenarioSteps = new StringBuilder();
+        if (!description.isEmpty()) {
+            result.setDescription(description);
+        }
+
+        final TestResultContainer resultContainer = new TestResultContainer()
+                .setName(String.format("%s: %s", scenarioDefinition.getKeyword(), scenarioDefinition.getName()))
+                .setUuid(getTestContainerUuid())
+                .setChildren(Collections.singletonList(getTestCaseUuid(currentTestCase.get())));
+
+        lifecycle.scheduleTestCase(result);
+        lifecycle.startTestContainer(getTestContainerUuid(), resultContainer);
+        lifecycle.startTestCase(getTestCaseUuid(currentTestCase.get()));
+
+        // custom code
+        ReportManagerHelper.setFeatureName(featureName);
+        lastStartedScenarioName = scenarioDefinition.getName();
+        ReportManagerHelper.setTestCaseName(lastStartedScenarioName);
+        ReportManagerHelper.setTestCaseDescription(scenarioDefinition.getDescription());
+        if (Boolean.parseBoolean(System.getProperty("generateExtentReports").trim())){
+            ReportManagerHelper.extentReportsCreateTest(feature.getName(), feature.getDescription());
+        }
+        var testCase = event.getTestCase();
+        var scenarioSteps = new StringBuilder();
         var cleanScenarioSteps = new StringBuilder();
         testCase.getTestSteps().forEach(testStep -> {
             if (testStep instanceof PickleStepTestStep pickleStepTestStep) {
@@ -71,20 +215,304 @@ public class CucumberFeatureListener implements ConcurrentEventListener {
                         .append(System.lineSeparator());
             }
         });
-        Optional<Feature> feature = getFeature(testCase.getUri());
-        if (feature.isPresent() && feature.get().getName().isPresent()) {
-            ReportManagerHelper.setFeatureName(feature.get().getName().get());
-        }
-        ReportManagerHelper.setTestCaseName(testCase.getName());
-        ReportManagerHelper.setTestCaseDescription(scenarioSteps.toString());
-        if (Boolean.parseBoolean(System.getProperty("generateExtentReports").trim())){
-            ReportManagerHelper.extentReportsCreateTest(testCase.getName(), scenarioSteps.toString());
-        }
-        ReportManagerHelper.logScenarioInformation(testCase.getKeyword(), testCase.getName(), cleanScenarioSteps.toString());
+        ReportManagerHelper.logScenarioInformation(scenarioDefinition.getKeyword(), lastStartedScenarioName, cleanScenarioSteps.toString());
     }
 
-    private Optional<Feature> getFeature(URI uri) {
-    	var featureParser = new FeatureParser(() -> new UUID(10, 1));
+    private void handleTestCaseFinished(final TestCaseFinished event) {
+        //custom code
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            if (System.getProperty("videoParams_scope").trim().equals("TestMethod")) {
+                RecordManager.attachVideoRecording();
+            }
+            ScreenshotManager.attachAnimatedGif();
+            // configuration method attachment is not added to the report (Allure ->
+            // threadContext.getCurrent(); -> empty)
+            ReportManagerHelper.attachTestLog(lastStartedScenarioName,
+                    InvokedMethodListener.createTestLog(Reporter.getOutput()));
+        } else {
+            ReportManagerHelper.attachTestLog(lastStartedScenarioName,
+                    InvokedMethodListener.createTestLog(Reporter.getOutput()));
+        }
+        // resetting scope and config
+        if (!DriverFactoryHelper.isMobileNativeExecution()) {
+            ElementActions.switchToDefaultContent();
+        }
+        shaftTeardown();
+        // end of custom code
+
+        final String uuid = getTestCaseUuid(event.getTestCase());
+        final Optional<StatusDetails> details = getStatusDetails(event.getResult().getError());
+        details.ifPresent(statusDetails -> lifecycle.updateTestCase(
+                uuid,
+                testResult -> testResult.setStatusDetails(statusDetails)
+        ));
+        lifecycle.stopTestCase(uuid);
+        lifecycle.stopTestContainer(getTestContainerUuid());
+        lifecycle.writeTestCase(uuid);
+        lifecycle.writeTestContainer(getTestContainerUuid());
+    }
+
+    private void handleTestStepStarted(final TestStepStarted event) {
+        if (event.getTestStep() instanceof PickleStepTestStep) {
+            final PickleStepTestStep pickleStep = (PickleStepTestStep) event.getTestStep();
+            final String stepKeyword = Optional.ofNullable(
+                    testSources.getKeywordFromSource(currentFeatureFile.get(), pickleStep.getStep().getLine())
+            ).orElse("UNDEFINED");
+
+            final StepResult stepResult = new StepResult()
+                    .setName(String.format("%s %s", stepKeyword, pickleStep.getStep().getText()))
+                    .setStart(System.currentTimeMillis());
+
+            lifecycle.startStep(getTestCaseUuid(currentTestCase.get()), getStepUuid(pickleStep), stepResult);
+
+            final StepArgument stepArgument = pickleStep.getStep().getArgument();
+            if (stepArgument instanceof DataTableArgument) {
+                final DataTableArgument dataTableArgument = (DataTableArgument) stepArgument;
+                createDataTableAttachment(dataTableArgument);
+            }
+        } else if (event.getTestStep() instanceof HookTestStep) {
+            initHook((HookTestStep) event.getTestStep());
+        }
+
+//        //custom code
+//        var testStep = event.getTestStep();
+//
+//        if (testStep instanceof HookTestStep hookTestStep) {
+//            ReportManager.logDiscrete("Scenario Hook: " + hookTestStep.getHookType().name());
+//            lastStartedStepName = hookTestStep.getHookType().name();
+//        }
+//
+//        if (testStep instanceof PickleStepTestStep pickleStepTestStep) {
+//            ReportManager.logDiscrete("Scenario Step: " + pickleStepTestStep.getStep().getKeyword() + pickleStepTestStep.getStep().getText());
+//            lastStartedStepName = pickleStepTestStep.getStep().getKeyword() + pickleStepTestStep.getStep().getText();
+//        }
+    }
+
+    private void initHook(final HookTestStep hook) {
+
+        final FixtureResult hookResult = new FixtureResult()
+                .setName(hook.getCodeLocation())
+                .setStart(System.currentTimeMillis());
+
+        if (hook.getHookType() == HookType.BEFORE) {
+            lifecycle.startPrepareFixture(getTestContainerUuid(), getHookStepUuid(hook), hookResult);
+        } else {
+            lifecycle.startTearDownFixture(getTestContainerUuid(), getHookStepUuid(hook), hookResult);
+        }
+
+    }
+
+    private void handleTestStepFinished(final TestStepFinished event) {
+        if (event.getTestStep() instanceof HookTestStep) {
+            handleHookStep(event);
+        } else {
+            handlePickleStep(event);
+        }
+
+        //custom code
+        isLastFinishedStepOK = event.getResult().getStatus().isOk();
+    }
+
+    private void handleWriteEvent(final WriteEvent event) {
+        lifecycle.addAttachment(
+                "Text output",
+                TEXT_PLAIN,
+                TXT_EXTENSION,
+                Objects.toString(event.getText()).getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private void handleEmbedEvent(final EmbedEvent event) {
+        lifecycle.addAttachment(event.name, event.getMediaType(), null, new ByteArrayInputStream(event.getData()));
+    }
+
+    /*
+    Utility Methods
+     */
+
+    private String getTestContainerUuid() {
+        return currentContainer.get();
+    }
+
+    private String getTestCaseUuid(final TestCase testCase) {
+        return scenarioUuids.computeIfAbsent(getHistoryId(testCase), it -> UUID.randomUUID().toString());
+    }
+
+    private String getStepUuid(final PickleStepTestStep step) {
+        return currentFeature.get().getName() + getTestCaseUuid(currentTestCase.get())
+                + step.getStep().getText() + step.getStep().getLine();
+    }
+
+    private String getHookStepUuid(final HookTestStep step) {
+        return currentFeature.get().getName() + getTestCaseUuid(currentTestCase.get())
+                + step.getHookType().toString() + step.getCodeLocation();
+    }
+
+    private String getHistoryId(final TestCase testCase) {
+        final String testCaseLocation = testCase.getUri().toString()
+                .substring(testCase.getUri().toString().lastIndexOf('/') + 1)
+                + ":" + testCase.getLocation().getLine();
+        return md5(testCaseLocation);
+    }
+
+    private Status translateTestCaseStatus(final Result testCaseResult) {
+        switch (testCaseResult.getStatus()) {
+            case FAILED:
+                return getStatus(testCaseResult.getError())
+                        .orElse(Status.FAILED);
+            case PASSED:
+                return Status.PASSED;
+            case SKIPPED:
+            case PENDING:
+                return Status.SKIPPED;
+            case AMBIGUOUS:
+            case UNDEFINED:
+            default:
+                return null;
+        }
+    }
+
+    private List<Parameter> getExamplesAsParameters(
+            final Scenario scenario, final TestCase localCurrentTestCase
+    ) {
+        final Optional<Examples> maybeExample =
+                scenario.getExamples().stream()
+                        .filter(example -> example.getTableBody().stream()
+                                .anyMatch(row -> row.getLocation().getLine()
+                                        == localCurrentTestCase.getLocation().getLine())
+                        )
+                        .findFirst();
+
+        if (!maybeExample.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        final Examples examples = maybeExample.get();
+
+        final Optional<TableRow> maybeRow = examples.getTableBody().stream()
+                .filter(example -> example.getLocation().getLine() == localCurrentTestCase.getLocation().getLine())
+                .findFirst();
+
+        if (!maybeRow.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        final TableRow row = maybeRow.get();
+
+        return IntStream.range(0, examples.getTableHeader().getCells().size())
+                .mapToObj(index -> {
+                    final String name = examples.getTableHeader().getCells().get(index).getValue();
+                    final String value = row.getCells().get(index).getValue();
+                    return createParameter(name, value);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void createDataTableAttachment(final DataTableArgument dataTableArgument) {
+        final List<List<String>> rowsInTable = dataTableArgument.cells();
+        final StringBuilder dataTableCsv = new StringBuilder();
+        for (List<String> columns : rowsInTable) {
+            if (!columns.isEmpty()) {
+                for (int i = 0; i < columns.size(); i++) {
+                    if (i == columns.size() - 1) {
+                        dataTableCsv.append(columns.get(i));
+                    } else {
+                        dataTableCsv.append(columns.get(i));
+                        dataTableCsv.append('\t');
+                    }
+                }
+                dataTableCsv.append('\n');
+            }
+        }
+        final String attachmentSource = lifecycle
+                .prepareAttachment("Data table", "text/tab-separated-values", "csv");
+        lifecycle.writeAttachment(attachmentSource,
+                new ByteArrayInputStream(dataTableCsv.toString().getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private void handleHookStep(final TestStepFinished event) {
+        final HookTestStep hookStep = (HookTestStep) event.getTestStep();
+        final String uuid = getHookStepUuid(hookStep);
+        final FixtureResult fixtureResult = new FixtureResult().setStatus(translateTestCaseStatus(event.getResult()));
+
+        if (!Status.PASSED.equals(fixtureResult.getStatus())) {
+            final TestResult testResult = new TestResult().setStatus(translateTestCaseStatus(event.getResult()));
+            final StatusDetails statusDetails = getStatusDetails(event.getResult().getError())
+                    .orElseGet(StatusDetails::new);
+
+            final String errorMessage = event.getResult().getError() == null ? hookStep.getHookType()
+                    .name() + " is failed." : hookStep.getHookType()
+                    .name() + " is failed: " + event.getResult().getError().getLocalizedMessage();
+            statusDetails.setMessage(errorMessage);
+
+            if (hookStep.getHookType() == HookType.BEFORE) {
+                testResult.setStatus(Status.SKIPPED);
+                updateTestCaseStatus(testResult.getStatus());
+                forbidTestCaseStatusChange.set(true);
+            } else {
+                testResult.setStatus(Status.BROKEN);
+                updateTestCaseStatus(testResult.getStatus());
+            }
+            fixtureResult.setStatusDetails(statusDetails);
+        }
+
+        lifecycle.updateFixture(uuid, result -> result.setStatus(fixtureResult.getStatus())
+                .setStatusDetails(fixtureResult.getStatusDetails()));
+        lifecycle.stopFixture(uuid);
+    }
+
+    private void handlePickleStep(final TestStepFinished event) {
+
+        final Status stepStatus = translateTestCaseStatus(event.getResult());
+        final StatusDetails statusDetails;
+        if (event.getResult().getStatus() == io.cucumber.plugin.event.Status.UNDEFINED) {
+            updateTestCaseStatus(Status.PASSED);
+
+            statusDetails =
+                    getStatusDetails(new IllegalStateException("Undefined Step. Please add step definition"))
+                            .orElse(new StatusDetails());
+            lifecycle.updateTestCase(getTestCaseUuid(currentTestCase.get()), scenarioResult ->
+                    scenarioResult
+                            .setStatusDetails(statusDetails));
+        } else {
+            statusDetails =
+                    getStatusDetails(event.getResult().getError())
+                            .orElse(new StatusDetails());
+            updateTestCaseStatus(stepStatus);
+        }
+
+        if (!Status.PASSED.equals(stepStatus) && stepStatus != null) {
+            forbidTestCaseStatusChange.set(true);
+        }
+
+        lifecycle.updateStep(getStepUuid((PickleStepTestStep) event.getTestStep()),
+                stepResult -> stepResult.setStatus(stepStatus).setStatusDetails(statusDetails));
+        lifecycle.stopStep(getStepUuid((PickleStepTestStep) event.getTestStep()));
+    }
+
+    private void updateTestCaseStatus(final Status status) {
+        if (!forbidTestCaseStatusChange.get()) {
+            lifecycle.updateTestCase(getTestCaseUuid(currentTestCase.get()),
+                    result -> result.setStatus(status));
+        }
+    }
+
+    // custom code
+    private void handleTestSourceParsed(TestSourceParsed event) {
+        event.getNodes().forEach(node -> {
+            Optional<io.cucumber.core.gherkin.Feature> feature = getFeature(event.getUri());
+            if (feature.isPresent()) {
+                if (ReportManagerHelper.getTotalNumberOfTests() == 0) {
+                    ReportManagerHelper.setTotalNumberOfTests(feature.get().getPickles().size());
+                } else {
+                    ReportManagerHelper.setTotalNumberOfTests(ReportManagerHelper.getTotalNumberOfTests() + feature.get().getPickles().size());
+                }
+            }
+        });
+    }
+    private Optional<io.cucumber.core.gherkin.Feature> getFeature(URI uri) {
+        var featureParser = new FeatureParser(() -> new UUID(10, 1));
         return featureParser.parseResource(new Resource() {
             @Override
             public URI getUri() {
@@ -98,15 +526,36 @@ public class CucumberFeatureListener implements ConcurrentEventListener {
         });
     }
 
-    private void handleTestStepStarted(TestStepStarted event) {
-    	var testStep = event.getTestStep();
-
-        if (testStep instanceof HookTestStep hookTestStep) {
-            ReportManager.logDiscrete("Scenario Hook: " + hookTestStep.getHookType().name());
+    private void shaftSetup(){
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            System.setProperty("disableLogging", "true");
+            PropertyFileManager.readPropertyFiles();
+            ImageProcessingActions.loadOpenCV();
+            System.setProperty("disableLogging", "false");
+            ReportManagerHelper.logEngineVersion();
+            ProjectStructureManager.initialize();
+            ReportManagerHelper.initializeAllureReportingEnvironment();
+            ReportManagerHelper.initializeExtentReportingEnvironment();
+            LogsHelper.attachImportantLinks();
+            LogsHelper.attachPropertyFiles();
+            ReportManagerHelper.generateJDKShellFilesToProjectDirectory();
+            ReportManagerHelper.setDiscreteLogging(Boolean.parseBoolean(System.getProperty("alwaysLogDiscreetly")));
+            ReportManagerHelper.setDebugMode(Boolean.valueOf(System.getProperty("debugMode")));
         }
+    }
 
-        if (testStep instanceof PickleStepTestStep pickleStepTestStep) {
-            ReportManager.logDiscrete("Scenario Step: " + pickleStepTestStep.getStep().getKeyword() + pickleStepTestStep.getStep().getText());
+    private void shaftTeardown(){
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            LogsHelper.closeAllDriversAndattachBrowserLogs();
+            LogsHelper.attachFullLogs();
+            LogsHelper.attachCucumberReport();
+            LogsHelper.attachExtentReport();
+            ReportManagerHelper.setDiscreteLogging(true);
+            ReportManagerHelper.generateAllureReportArchive();
+            ReportManagerHelper.openAllureReportAfterExecution();
+            AlterSuiteListener.reportExecutionStatusToJira();
         }
     }
 }

--- a/src/main/java/com/shaft/tools/listeners/CucumberTestRunnerListener.java
+++ b/src/main/java/com/shaft/tools/listeners/CucumberTestRunnerListener.java
@@ -1,0 +1,184 @@
+package com.shaft.tools.listeners;
+
+import com.shaft.cli.FileActions;
+import com.shaft.driver.DriverFactoryHelper;
+import com.shaft.gui.element.ElementActions;
+import com.shaft.gui.image.ImageProcessingActions;
+import com.shaft.gui.image.ScreenshotManager;
+import com.shaft.gui.video.RecordManager;
+import com.shaft.tools.io.*;
+import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.resource.Resource;
+import io.cucumber.plugin.ConcurrentEventListener;
+import io.cucumber.plugin.event.*;
+import org.testng.Reporter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+
+public class CucumberTestRunnerListener implements ConcurrentEventListener {
+
+    private static String lastStartedScenarioName;
+
+    private static String lastStartedStepName;
+    public static String getLastStartedStepName(){
+        return lastStartedStepName;
+    }
+
+    private static Boolean isLastFinishedStepOK;
+    public static Boolean getIsLastFinishedStepOK(){
+        return isLastFinishedStepOK;
+    }
+
+    @Override
+    public void setEventPublisher(EventPublisher publisher) {
+        //https://github.com/cucumber/cucumber-jvm/issues/1901
+        //https://github.com/cucumber/cucumber-jvm/issues/1901#issuecomment-600494342
+        publisher.registerHandlerFor(TestRunStarted.class, this::handleTestRunStarted);
+        publisher.registerHandlerFor(TestRunFinished.class, this::handleTestRunFinished);
+        publisher.registerHandlerFor(TestCaseStarted.class, this::caseStartedHandler);
+        publisher.registerHandlerFor(TestCaseFinished.class, this::caseFinishedHandler);
+        publisher.registerHandlerFor(TestStepStarted.class, this::stepStartedHandler);
+        publisher.registerHandlerFor(TestStepFinished.class, this::stepFinishedHandler);
+        publisher.registerHandlerFor(TestSourceParsed.class, this::handleTestSourceParsed);
+    }
+
+    private void handleTestSourceParsed(TestSourceParsed event) {
+        event.getNodes().forEach(node -> {
+            Optional<Feature> feature = getFeature(event.getUri());
+            if (feature.isPresent()) {
+                if (ReportManagerHelper.getTotalNumberOfTests() == 0) {
+                    ReportManagerHelper.setTotalNumberOfTests(feature.get().getPickles().size());
+                } else {
+                    ReportManagerHelper.setTotalNumberOfTests(ReportManagerHelper.getTotalNumberOfTests() + feature.get().getPickles().size());
+                }
+            }
+        });
+    }
+
+    private void handleTestRunStarted(TestRunStarted event) {
+        shaftSetup();
+    }
+
+    private void handleTestRunFinished(TestRunFinished event) {
+        shaftTeardown();
+    }
+
+
+    private void shaftSetup(){
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            System.setProperty("disableLogging", "true");
+            PropertyFileManager.readPropertyFiles();
+            ImageProcessingActions.loadOpenCV();
+            System.setProperty("disableLogging", "false");
+            ReportManagerHelper.logEngineVersion();
+            ProjectStructureManager.initialize();
+            ReportManagerHelper.initializeAllureReportingEnvironment();
+            ReportManagerHelper.initializeExtentReportingEnvironment();
+            LogsHelper.attachImportantLinks();
+            LogsHelper.attachPropertyFiles();
+            ReportManagerHelper.generateJDKShellFilesToProjectDirectory();
+            ReportManagerHelper.setDiscreteLogging(Boolean.parseBoolean(System.getProperty("alwaysLogDiscreetly")));
+            ReportManagerHelper.setDebugMode(Boolean.valueOf(System.getProperty("debugMode")));
+        }
+    }
+
+    private void shaftTeardown(){
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            LogsHelper.closeAllDriversAndattachBrowserLogs();
+            LogsHelper.attachFullLogs();
+            LogsHelper.attachCucumberReport();
+            LogsHelper.attachExtentReport();
+            ReportManagerHelper.setDiscreteLogging(true);
+            ReportManagerHelper.generateAllureReportArchive();
+            ReportManagerHelper.openAllureReportAfterExecution();
+            AlterSuiteListener.reportExecutionStatusToJira();
+        }
+    }
+
+    private void caseStartedHandler(TestCaseStarted event) {
+        var testCase = event.getTestCase();
+    	var scenarioSteps = new StringBuilder();
+        var cleanScenarioSteps = new StringBuilder();
+        testCase.getTestSteps().forEach(testStep -> {
+            if (testStep instanceof PickleStepTestStep pickleStepTestStep) {
+                scenarioSteps.append("<b style=\"color:ForestGreen;\">")
+                        .append(pickleStepTestStep.getStep().getKeyword())
+                        .append("</b>")
+                        .append(pickleStepTestStep.getStep().getText())
+                        .append("<br/>");
+                cleanScenarioSteps.append(pickleStepTestStep.getStep().getKeyword())
+                        .append(pickleStepTestStep.getStep().getText())
+                        .append(System.lineSeparator());
+            }
+        });
+        Optional<Feature> feature = getFeature(testCase.getUri());
+        if (feature.isPresent() && feature.get().getName().isPresent()) {
+            ReportManagerHelper.setFeatureName(feature.get().getName().get());
+        }
+        ReportManagerHelper.setTestCaseName(testCase.getName());
+        ReportManagerHelper.setTestCaseDescription(scenarioSteps.toString());
+        if (Boolean.parseBoolean(System.getProperty("generateExtentReports").trim())){
+            ReportManagerHelper.extentReportsCreateTest(testCase.getName(), scenarioSteps.toString());
+        }
+        lastStartedScenarioName = testCase.getName();
+        ReportManagerHelper.logScenarioInformation(testCase.getKeyword(), lastStartedScenarioName, cleanScenarioSteps.toString());
+    }
+
+    private void caseFinishedHandler(TestCaseFinished event) {
+        if (Reporter.getCurrentTestResult() == null) {
+            // running in native Cucumber mode
+            if (System.getProperty("videoParams_scope").trim().equals("TestMethod")) {
+                RecordManager.attachVideoRecording();
+            }
+            ScreenshotManager.attachAnimatedGif();
+            // configuration method attachment is not added to the report (Allure ->
+            // threadContext.getCurrent(); -> empty)
+            ReportManagerHelper.attachTestLog(lastStartedScenarioName,
+                    InvokedMethodListener.createTestLog(Reporter.getOutput()));
+        }
+        // resetting scope and config
+        if (!DriverFactoryHelper.isMobileNativeExecution()) {
+            ElementActions.switchToDefaultContent();
+        }
+    }
+
+    private Optional<Feature> getFeature(URI uri) {
+    	var featureParser = new FeatureParser(() -> new UUID(10, 1));
+        return featureParser.parseResource(new Resource() {
+            @Override
+            public URI getUri() {
+                return uri;
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return new ByteArrayInputStream(FileActions.readFromFile(uri.getPath()).getBytes());
+            }
+        });
+    }
+
+    private void stepStartedHandler(TestStepStarted event) {
+    	var testStep = event.getTestStep();
+
+        if (testStep instanceof HookTestStep hookTestStep) {
+            ReportManager.logDiscrete("Scenario Hook: " + hookTestStep.getHookType().name());
+            lastStartedStepName = hookTestStep.getHookType().name();
+        }
+
+        if (testStep instanceof PickleStepTestStep pickleStepTestStep) {
+            ReportManager.logDiscrete("Scenario Step: " + pickleStepTestStep.getStep().getKeyword() + pickleStepTestStep.getStep().getText());
+            lastStartedStepName = pickleStepTestStep.getStep().getKeyword() + pickleStepTestStep.getStep().getText();
+        }
+    }
+
+    private void stepFinishedHandler(TestStepFinished event) {
+        isLastFinishedStepOK = event.getResult().getStatus().isOk();
+    }
+}

--- a/src/main/java/com/shaft/tools/listeners/InvokedMethodListener.java
+++ b/src/main/java/com/shaft/tools/listeners/InvokedMethodListener.java
@@ -215,7 +215,7 @@ public class InvokedMethodListener implements IInvokedMethodListener {
         listOfOpenIssuesForPassedTests.add(newIssue);
     }
 
-    private String createTestLog(List<String> output) {
+    public static String createTestLog(List<String> output) {
         StringBuilder builder = new StringBuilder();
         for (String each : output) {
             builder.append(each).append(System.lineSeparator());

--- a/src/main/java/com/shaft/tools/support/JavaActions.java
+++ b/src/main/java/com/shaft/tools/support/JavaActions.java
@@ -4,6 +4,7 @@ import com.shaft.tools.io.ReportManagerHelper;
 import org.testng.Assert;
 
 import java.util.Base64;
+import java.util.regex.Pattern;
 
 public class JavaActions {
 
@@ -34,6 +35,19 @@ public class JavaActions {
             text = text.replace(oldChar, specialCharactersArray[i]);
         }
         return text;
+    }
+
+    public static String removeSpecialCharacters(String text){
+        StringBuilder cleanString = new StringBuilder();
+        for (int i=0; i< text.toCharArray().length; i++){
+            var character = String.valueOf(text.toCharArray()[i]);
+            if(Pattern.compile("[^a-z0-9]", Pattern.CASE_INSENSITIVE).matcher(character).find()){
+                cleanString.append("_");
+            }else{
+                cleanString.append(character);
+            }
+        }
+        return cleanString.toString();
     }
 
     /**

--- a/src/main/resources/defaultProperties/cucumber.properties
+++ b/src/main/resources/defaultProperties/cucumber.properties
@@ -1,5 +1,30 @@
-cucumber.filter.tags=
+#############
+# https://cucumber.io/docs/cucumber/api/#list-configuration-options
+##############
+cucumber.ansi-colors.disabled=false
+#true or false. default: false
+cucumber.execution.dry-run=false
+#true or false. default: false
+cucumber.execution.limit=
+#number of scenarios to execute (CLI only).
+cucumber.execution.order=lexical
+#lexical, reverse, random or random:[seed] (CLI only). default: lexical
+cucumber.execution.strict=true
+#true or false. default: true.
+cucumber.execution.wip=false
+#true or false. default: false.
 cucumber.features=src/test/resources
-cucumber.extraGlue=
-cucumber.plugin=pretty, json:allure-results/cucumber.json, html:allure-results/cucumberReport.html, com.shaft.tools.listeners.CucumberFeatureListener
-cucumber.glue=com.shaft.cucumber
+#comma separated paths to feature files. example: path/to/example.feature, path/to/other.feature
+cucumber.filter.name=
+#regex. example: .*Hello.*
+cucumber.filter.tags=
+#tag expression. example: @smoke and not @slow
+cucumber.glue=customCucumberSteps, com.shaft.cucumber
+# comma separated package names. example: com.example.glue
+cucumber.plugin=pretty, json:allure-results/cucumber.json, html:allure-results/cucumberReport.html, com.shaft.tools.listeners.CucumberTestRunnerListener
+# comma separated plugin strings. example: pretty, json:path/to/report.json
+cucumber.object-factory=
+#object factory class name. example: com.example.MyObjectFactory
+cucumber.snippet-type=underscore
+#underscore or camelcase. default: underscore
+cucumber.publish.quiet=true

--- a/src/test/java/customCucumberSteps/steps.java
+++ b/src/test/java/customCucumberSteps/steps.java
@@ -52,16 +52,4 @@ public class steps {
                 .withCustomReportMessage("Check that first result text contains ["+expectedText+"]")
                 .perform();
     }
-    @Before
-    public void before(){
-        ReportManager.log("This is @Before");
-    }
-    @BeforeAll
-    public static void beforeAll(){
-        ReportManager.log("This is @BeforeAll");
-    }
-    @BeforeStep
-    public void beforeStep(){
-        ReportManager.log("This is @BeforeStep");
-    }
 }

--- a/src/test/java/testPackage01/Test_Healenium.java
+++ b/src/test/java/testPackage01/Test_Healenium.java
@@ -7,7 +7,6 @@ import com.shaft.tools.io.ReportManager;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -22,6 +21,13 @@ public class Test_Healenium {
 . research if healenium report can be generated manually and attached to the allure report
 . capture healenium logs in shaft logs
 . create user guide or video on how to use healenium with shaft and the needed manual step to initialize healenium backend
+     */
+
+    /*
+    Steps to use Healinium with SHAFT
+    1. Run the docker-compose file under src/main/resources/docker-compose/healenium-backend.yml
+    2. Ensure that the 'heal-enabled' property is set to 'true'
+    3. Run this test class to ensure that everything is working as expected
      */
 
     @Test

--- a/src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature
+++ b/src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature
@@ -6,12 +6,12 @@ Feature: Basic SHAFT_Engine BDD POC
     When I Navigate to "https://www.google.com/ncr" and get redirected to "https://www.google.com/"
     And I Type "SHAFT_Engine" into the element found by "name": "q"
     And I Press the "Enter" key into the element found by "name": "q"
-    Then I Assert that the "href" attribute of the element found by "xpath": "(//h2[text()='Web result with site links']/following::a)[1]", equals "https://github.com/MohabMohie/SHAFT_ENGINE"
+    Then I Assert that the "href" attribute of the element found by "xpath": "(//h3[contains(@class,'LC20lb')])[1]/parent::a", equals "https://github.com/MohabMohie/SHAFT_ENGINE"
     And I Close the current window
 
-#  @smoke
-#  Scenario: TC002 - Open Browser, Navigate to Google, Assert Page Title
-#    Given I Open the target browser
-#    When I Navigate to "https://www.google.com/ncr" and get redirected to "https://www.google.com/"
-#    Then I Assert that the "Title" attribute of the browser, equals "Google"
-#    And I Close the current window
+  @smoke
+  Scenario: TC002 - Open Browser, Navigate to Google, Assert Page Title
+    Given I Open the target browser
+    When I Navigate to "https://www.google.com/ncr" and get redirected to "https://www.google.com/"
+    Then I Assert that the "Title" attribute of the browser, equals "Google"
+    And I Close the current window

--- a/src/test/resources/CustomCucumberFeatures/googleTest.feature
+++ b/src/test/resources/CustomCucumberFeatures/googleTest.feature
@@ -1,5 +1,4 @@
-Feature:
-  Sample Feature file to test custom cucumber steps
+Feature: Sample Feature file to test custom cucumber steps
 
   Scenario: This is the first test scenario in the sample feature file
     Given I open the target browser


### PR DESCRIPTION
. AlterSuiteListener
- optimize imports
- remove unused listener implementation
- remove SHAFT prefix from all test suites/cases
- fix added listeners
- remove discrete log messages

. BrowserSteps
- optimize imports and remove deprecated method

. cucumber.properties
- major refactor with new default values

. CucumberFeatureListener
- new custom plugin to run feature files directly

. CucumberTestRunnerListener
- enhanced custom listener to run using a cucumber test runner class

. ImageProcessingActions
- resolved OpenCV initialization throwable by force switching to JavaScript for element highlighting

. InvokedMethodListener
- exposed some methods to be used in the new plugins

. JavaActions
- created "removeSpecialCharacters" method to be used to process screenshot images file names

. LogsHelper
- optimized imports
- exposed some public static methods to be used with the new plugins

. pom.xml
- version bump
- adding "allure-cucumber7-jvm"

. ReportManagerHelper
- Customized report entry for dynamic test runner
- bypassed bug that prevented allure directory from being deleted
- exposed more methods to be called by the new plugins